### PR TITLE
Fixes onLoad*, onError events not called from child component

### DIFF
--- a/lib/webview.js
+++ b/lib/webview.js
@@ -67,12 +67,12 @@ class ProgressBarWebView extends React.PureComponent {
 			<View style={styles.container}>
 				{visible && <LoadingBar height={height} color={color} percent={percent}/>}
 				<WebView
+					{...this.props}
 					ref={forwardedRef}
 					onLoadStart={this._onLoadStart}
 					onLoadEnd={this._onLoadEnd}
 					onLoadProgress={this._onLoadProgress}
 					onError={this._onError}
-					{...this.props}
 				/>
 			</View>
 		);


### PR DESCRIPTION
If the child component also defines the same onload methods this component defines, then this component's events won't be called and thus the bar will not render.